### PR TITLE
Optimise device recognition

### DIFF
--- a/src/main/kotlin/com/balsdon/androidallyplugin/constants.kt
+++ b/src/main/kotlin/com/balsdon/androidallyplugin/constants.kt
@@ -4,3 +4,4 @@ const val elementMaxHeight = 40 // TODO: This should be a calculation
 
 const val TB4DWebPage = "https://ally-keys.com/tb4d.html"
 const val TB4DInstallHelpWebPage = "$TB4DWebPage#installation-help"
+const val TB4DPackageName = "com.android.talkback4d"

--- a/src/main/kotlin/com/balsdon/androidallyplugin/model/BasicDeviceInfo.kt
+++ b/src/main/kotlin/com/balsdon/androidallyplugin/model/BasicDeviceInfo.kt
@@ -1,0 +1,3 @@
+package com.balsdon.androidallyplugin.model
+
+data class BasicDeviceInfo(val name: String, val api: String, val sdk: String, val packageList: List<String>)


### PR DESCRIPTION
[TICKET 1](https://trello.com/c/BgMdeSPp)
[TICKET 2](https://trello.com/c/LbYEePIz)

Fixed emulator name error and issue where device details were delayed. 
Also optimmised the process of detecting installed packages and adding the installation panel. 

These issues were all related - the emulator needs to accessa property called  "avdData"  which actually returns a `ListenableFuture<AvdData>` - which means it needs to wait. Coupling all the initial wait calls until the device is ready seems to make the whole experience a lot better.