### PR TITLE
Added notification to tell users no device is selected

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -37,9 +37,10 @@ intellij {
         "Giraffe" to "223.8836.35.2231.11090377",
         "Hedgehog" to "231.9392.1.2311.11330709",
         "Iguana" to "232.10227.8.2321.11379558",
-        "Jellyfish" to "233.14475.28.2331.11543046",
+        "Jellyfish" to "233.14808.21.2331.11643467",
+        "Koala" to "233.14475.28.2332.11606850",
     )
-    val intellijVersion = androidStudioVersion["Iguana"] // https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration
+    val intellijVersion = androidStudioVersion["Koala"] // https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration
     version.set(intellijVersion)
     type.set("AI") // Target Android Studio IDE Platform
     plugins.set(listOf("android"))

--- a/src/main/kotlin/com/balsdon/androidallyplugin/controller/AndroidStudioPluginController.kt
+++ b/src/main/kotlin/com/balsdon/androidallyplugin/controller/AndroidStudioPluginController.kt
@@ -129,10 +129,20 @@ class AndroidStudioPluginController(
         ))
     }
 
+    private fun showNoSelectedDevicesNotification() {
+        showNotification(AndroidStudioPluginNotificationPayload(
+            localize("plugin.notification.no_devices.title"),
+            localize("plugin.notification.no_devices.message"),
+            notificationType = NotificationType.ERROR,
+            actions = emptyList()
+        ))
+    }
+
     override fun runOnAllValidSelectedDevices(fn: (AndroidDevice) -> Unit) {
         connectedDeviceList
             .filter { it.serial in selectedDeviceSerialList }
             .map { fn(it) }
+            .ifEmpty { showNoSelectedDevicesNotification() }
     }
 
     override fun refreshAdb() = adbProvider.refreshAdb()

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -53,6 +53,7 @@
         </ul>
         <h2>Bug fixes</h2>
         <ul>
+            <li>[0.0.8] No devices selected warning <a href="https://trello.com/c/iGB442Ik">Trello issue link</a></li>
             <li>[0.0.7] Removed duplicated word in heading <a href="https://github.com/qbalsdon/android-ally-plugin/pull/30">Pull request</a></li>
             <li>[0.0.7] Added detekt for code linting <a href="https://trello.com/c/Uf7KogQC">Trello issue link</a></li>
             <li>[0.0.7] Fixed the way light and dark icons are loaded, removed unused image references <a href="https://trello.com/c/upTMdfcW">Trello issue link</a></li>

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -142,3 +142,6 @@ notification.voice.access.help.action=Why aren't there controls here?
 notification.switch.access.help.title=Switch Access
 notification.switch.access.help.message=You can set up Switch Access to use your volume keys from Settings -> Accessibility -> Switch Access -> Settings. Also recommended is to set auto-select to false, so you can test actions.
 notification.switch.access.help.action=Why aren't there controls here?
+
+plugin.notification.no_devices.title=No devices selected
+plugin.notification.no_devices.message=Please select one or more devices on which to perform an action

--- a/src/test/kotlin/com/balsdon/androidallyplugin/controller/AndroidStudioPluginControllerTest.kt
+++ b/src/test/kotlin/com/balsdon/androidallyplugin/controller/AndroidStudioPluginControllerTest.kt
@@ -20,6 +20,7 @@ import org.jetbrains.kotlin.backend.common.push
 import org.junit.Assert
 import org.junit.Test
 
+
 class AndroidStudioPluginControllerTest {
     @Test
     fun adds_new_devices() {
@@ -148,15 +149,18 @@ class AndroidStudioPluginControllerTest {
 
         // when
         //    runOnAllValidSelectedDevices called
-        val devicesActedUpon = mutableListOf<AndroidDevice>()
-        testSubject.runOnAllValidSelectedDevices { device -> devicesActedUpon.push(device) }
-
+        var deviceCount = 0
+        try {
+            testSubject.runOnAllValidSelectedDevices { _ -> deviceCount += 1 }
+        } catch (e: NullPointerException) {
+            assertThat(e.stackTrace.count { element -> element.methodName == "showNoSelectedDevicesNotification" }).isEqualTo(1)
+        }
         // then the resulting devices acted on is 0
-        assertThat(devicesActedUpon.size).isEqualTo(0)
+        assertThat(deviceCount).isEqualTo(0)
     }
 
     @Test
-    fun function_not_run_when_one_device_selected() {
+    fun function_run_when_one_device_selected() {
         // given a controller
         val testSubject = AndroidStudioPluginController(
             projectFake,


### PR DESCRIPTION
- [x] [Ticket reference](https://trello.com/c/iGB442Ik)
- [x] I have written unit tests for my changes
- [x] I have tested my changes locally in the last three (3) versions of Android Studio
- [x] Updated the plugin.xml file with the changes
- [x] Added a before and after screenshot for any UI changes
- This code does not have:
  - [x] object classes
  - [x] companion objects
 
After:
<img width="379" alt="JetBrains notification error with title 'No devices selected' and text 'Please select one or more devices on which to perform an action'" src="https://github.com/qbalsdon/android-ally-plugin/assets/1086536/54925192-d47e-40b7-9758-adb1eb41af1c">

 
