### PR TITLE
Added home button to TalkBack panel

### DIFF
--- a/src/main/kotlin/com/balsdon/androidallyplugin/ui/panel/TalkBackPanel.kt
+++ b/src/main/kotlin/com/balsdon/androidallyplugin/ui/panel/TalkBackPanel.kt
@@ -45,6 +45,7 @@ class TalkBackPanel(controller: Controller) : ControllerPanel(controller) {
     private val nextButtonText = localize("panel.talkback.button.next")
     private val tapButtonText = localize("panel.talkback.button.tap")
     private val longTapButtonText = localize("panel.talkback.button.longTap")
+    private val homeButtonText = localize("panel.talkback.button.home")
     private val backButtonText = localize("panel.talkback.button.back")
     private val menuButtonText = localize("panel.talkback.button.menu")
     private val actionsButtonText = localize("panel.talkback.button.actions")
@@ -195,6 +196,14 @@ class TalkBackPanel(controller: Controller) : ControllerPanel(controller) {
                 ""
             ) { AdbScript.PressKeyAdb(AdbKeyCode.BACK).run() }.create(),
             x = 3, y = whichRow, fillType = GridBagConstraints.BOTH
+        )
+        placeComponent(
+            IconButton(
+                CustomIcon.DEVICE_HOME,
+                homeButtonText,
+                ""
+            ) { AdbScript.PressKeyAdb(AdbKeyCode.HOME).run() }.create(),
+            x = 4, y = whichRow, fillType = GridBagConstraints.BOTH
         )
         placeComponent(
             IconButton(

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -48,6 +48,7 @@
     <change-notes><![CDATA[
         <h2>Whats new</h2>
         <ul>
+            <li>[0.0.8] Added a home button <a href="https://trello.com/c/NrhyxaIk">Trello issue link</a></li>
             <li>[0.0.7] Added WearOS support <a href="https://trello.com/c/HBTuwZWE">Trello issue link</a></li>
             <li>[0.0.6] Added reset font scale button <a href="https://trello.com/c/PHGrQq5V">Trello issue link</a></li>
         </ul>

--- a/src/main/resources/Strings.properties
+++ b/src/main/resources/Strings.properties
@@ -40,6 +40,7 @@ panel.talkback.button.previous=Previous
 panel.talkback.button.next=Next
 panel.talkback.button.tap=Tap
 panel.talkback.button.longTap=LongTap
+panel.talkback.button.home=Home
 panel.talkback.button.back=Back
 panel.talkback.button.menu=Menu
 panel.talkback.button.actions=Actions


### PR DESCRIPTION
- [x] [Ticket reference](https://trello.com/c/NrhyxaIk)
- ~I have written unit tests for my changes~: Purely visiual and functions have already been tested
- [x] I have tested my changes locally in the last three (3) versions of Android Studio
- [x] Updated the plugin.xml file with the changes
- [x] Added a before and after screenshot for any UI changes
- This code does not have:
  - [x] object classes
  - [x] companion objects
  
# Before
<img width="890" alt="Android Ally panel with tabs: TalkBack (selected), Display, Settings, Debug. The pane has a toggle for turning talkback on and off, a granularity drop down, and navigation has buttons: previous, next, tap, long tap, back, no button, menu, actions. There are buttons for toggling volume, speech output and the block out view" src="https://github.com/qbalsdon/android-ally-plugin/assets/1086536/814d7d22-a82c-4032-850f-288596779562">


# After
<img width="1114" alt="Android Ally panel with tabs: TalkBack (selected), Display, Settings, Debug. The pane has a toggle for turning talkback on and off, a granularity drop down, and navigation has buttons: previous, next, tap, long tap, back, home, menu, actions. There are buttons for toggling volume, speech output and the block out view" src="https://github.com/qbalsdon/android-ally-plugin/assets/1086536/9fe125b1-9223-40b3-b956-4d3026dae112">
